### PR TITLE
feat: username validation 

### DIFF
--- a/server/server/src/main/java/com/cactusvilleage/server/auth/service/CustomOAuth2UserService.java
+++ b/server/server/src/main/java/com/cactusvilleage/server/auth/service/CustomOAuth2UserService.java
@@ -64,22 +64,20 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     }
 
     private void checkUsername(OAuth2UserInfo oAuth2UserInfo, Member member) {
-        String username;
-        if (oAuth2UserInfo.getName().length() > 8) {
-            username = oAuth2UserInfo.getName().substring(0, 8);
-        } else {
-            username = oAuth2UserInfo.getName();
-        }
+
+        String username = oAuth2UserInfo.getName();
 
         if (memberRepository.existsByUsername(username)) {
             long count = memberRepository.findAll().stream()
-                    .filter(foundMember -> foundMember.getUsername().startsWith(username) && StringUtils.isNumeric(foundMember.getUsername().substring(username.length())))
-                    .count();
-            member.setUsername(username + (count + 1));
+                    .filter(foundMember -> foundMember.getUsername().startsWith(username)
+                            && foundMember.getUsername().substring(username.length()).startsWith(" #")
+                            && StringUtils.isNumeric(foundMember.getUsername().substring(username.length() + 2)))
+                    .count() + 1;
+            member.setUsername(username + " #" + (count + 1));
             if (memberRepository.existsByUsername(member.getUsername())) {
                 while (!memberRepository.existsByUsername(member.getUsername())) {
                     int suffix = Integer.parseInt(member.getUsername().substring(username.length())) + 1;
-                    member.setUsername(username + suffix);
+                    member.setUsername(username + " #" + suffix);
                 }
             }
         } else {

--- a/server/server/src/main/java/com/cactusvilleage/server/auth/service/CustomOAuth2UserService.java
+++ b/server/server/src/main/java/com/cactusvilleage/server/auth/service/CustomOAuth2UserService.java
@@ -65,7 +65,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
     private void checkUsername(OAuth2UserInfo oAuth2UserInfo, Member member) {
 
-        String username = oAuth2UserInfo.getName();
+        String username = oAuth2UserInfo.getName().trim();
 
         if (memberRepository.existsByUsername(username)) {
             long count = memberRepository.findAll().stream()

--- a/server/server/src/main/java/com/cactusvilleage/server/auth/validator/SpaceCantBeAtBeginOrEnd.java
+++ b/server/server/src/main/java/com/cactusvilleage/server/auth/validator/SpaceCantBeAtBeginOrEnd.java
@@ -1,0 +1,17 @@
+package com.cactusvilleage.server.auth.validator;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = SpaceValidator.class)
+public @interface SpaceCantBeAtBeginOrEnd {
+    String message() default "닉네임 앞뒤로는 공백이 들어갈 수 없습니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/server/server/src/main/java/com/cactusvilleage/server/auth/validator/SpaceValidator.java
+++ b/server/server/src/main/java/com/cactusvilleage/server/auth/validator/SpaceValidator.java
@@ -1,0 +1,12 @@
+package com.cactusvilleage.server.auth.validator;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class SpaceValidator implements ConstraintValidator<SpaceCantBeAtBeginOrEnd, String> {
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        return !value.startsWith(" ") && !value.endsWith(" ");
+    }
+}

--- a/server/server/src/main/java/com/cactusvilleage/server/auth/web/config/CorsConfig.java
+++ b/server/server/src/main/java/com/cactusvilleage/server/auth/web/config/CorsConfig.java
@@ -19,7 +19,7 @@ public class CorsConfig {
 
         config.addAllowedMethod("*");
         config.addExposedHeader("Authorization");
-        config.addExposedHeader("*");
+//        config.addExposedHeader("*");
 
         source.registerCorsConfiguration("/**", config);
 

--- a/server/server/src/main/java/com/cactusvilleage/server/auth/web/dto/request/EditDto.java
+++ b/server/server/src/main/java/com/cactusvilleage/server/auth/web/dto/request/EditDto.java
@@ -1,5 +1,6 @@
 package com.cactusvilleage.server.auth.web.dto.request;
 
+import com.cactusvilleage.server.auth.validator.SpaceCantBeAtBeginOrEnd;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.lang.Nullable;
@@ -10,6 +11,7 @@ import javax.validation.constraints.Size;
 @AllArgsConstructor
 public class EditDto {
     @Nullable
+    @SpaceCantBeAtBeginOrEnd
     private String username;
     @Nullable
     private String prePassword;

--- a/server/server/src/main/java/com/cactusvilleage/server/auth/web/dto/request/EditDto.java
+++ b/server/server/src/main/java/com/cactusvilleage/server/auth/web/dto/request/EditDto.java
@@ -10,7 +10,6 @@ import javax.validation.constraints.Size;
 @AllArgsConstructor
 public class EditDto {
     @Nullable
-    @Size(min = 2, max = 8)
     private String username;
     @Nullable
     private String prePassword;

--- a/server/server/src/main/java/com/cactusvilleage/server/auth/web/dto/request/PlainSignupDto.java
+++ b/server/server/src/main/java/com/cactusvilleage/server/auth/web/dto/request/PlainSignupDto.java
@@ -24,7 +24,6 @@ public class PlainSignupDto {
     @EmailNotDuplicate
     private String email;
 
-    @Size(min = 2, max = 8)
     @NotBlank
     @UsernameNotDuplicate
     private String username;

--- a/server/server/src/main/java/com/cactusvilleage/server/auth/web/dto/request/PlainSignupDto.java
+++ b/server/server/src/main/java/com/cactusvilleage/server/auth/web/dto/request/PlainSignupDto.java
@@ -2,6 +2,7 @@ package com.cactusvilleage.server.auth.web.dto.request;
 
 import com.cactusvilleage.server.auth.entities.Member;
 import com.cactusvilleage.server.auth.validator.EmailNotDuplicate;
+import com.cactusvilleage.server.auth.validator.SpaceCantBeAtBeginOrEnd;
 import com.cactusvilleage.server.auth.validator.UsernameNotDuplicate;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -26,6 +27,7 @@ public class PlainSignupDto {
 
     @NotBlank
     @UsernameNotDuplicate
+    @SpaceCantBeAtBeginOrEnd
     private String username;
 
     @Size(min = 8, max = 20)

--- a/server/server/src/main/java/com/cactusvilleage/server/auth/web/dto/request/RecoveryDto.java
+++ b/server/server/src/main/java/com/cactusvilleage/server/auth/web/dto/request/RecoveryDto.java
@@ -5,7 +5,6 @@ import lombok.Getter;
 
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.Size;
 
 @Getter
 @AllArgsConstructor
@@ -14,6 +13,5 @@ public class RecoveryDto {
     @NotBlank
     private String email;
 
-    @Size(min = 2, max = 8)
     private String username;
 }


### PR DESCRIPTION
- username 길이 제한 해제
- username 앞뒤로 공백 불가
- 소셜 회원 가입 시 기존 닉네임과 중복 되는 경우 `'닉네임' + ' #' + '{number}'` 형태로 저장되도록 수정
  - eg. `닉네임 #2`