### PR TITLE
feat: create location path Slice in RTX for Nav

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -18,7 +18,6 @@
     "react-redux": "^8.0.4",
     "react-router-dom": "^6.4.0",
     "react-scripts": "5.0.1",
-    "redux": "^4.2.0",
     "styled-components": "^5.3.5",
     "styled-reset": "^4.4.2",
     "web-vitals": "^2.1.4"

--- a/client/src/feature/challenge/previousChallengesSlice.ts
+++ b/client/src/feature/challenge/previousChallengesSlice.ts
@@ -1,0 +1,20 @@
+// import { RootState } from './../store/store';
+// import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+// // api 요청 함수 import해오기
+
+// interface PreviousChallenges {
+//   value: string
+// }
+
+// const initialState: PreviousChallenges = {
+//   value: 'hi'
+// };
+
+// export const fetchPreviousChallenges = createAsyncThunk(
+//   'mypage/fetchPreviousChallenges',
+//   async (totalData: [], thunkAPI) => {
+//     const response = await 'import해온 API'.fetchPreviousChallenges(value);
+//     return response.data;
+//   }
+// );
+export {};

--- a/client/src/feature/location/locationSlice.ts
+++ b/client/src/feature/location/locationSlice.ts
@@ -1,0 +1,25 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+// 위치만 저장한다.
+// boolean값을 저장하면-> 새로고침시 원하지않은 결과 발생
+// 언제 저장한 위치를 바꿀것인가? -> 버튼클릭시
+interface InitialLocation {
+  path: string
+}
+
+const initialLocation: InitialLocation = {
+  path: window.location.pathname
+};
+
+const locaitionSlice = createSlice({
+  name: 'location',
+  initialState: initialLocation,
+  reducers: {
+    click: (state, action: PayloadAction<InitialLocation>) => {
+      state.path = action.payload.path;
+    }
+  }
+});
+
+export const { click } = locaitionSlice.actions;
+export default locaitionSlice.reducer;

--- a/client/src/store/store.ts
+++ b/client/src/store/store.ts
@@ -1,9 +1,11 @@
 import { configureStore } from '@reduxjs/toolkit';
-import userReducer from '../feature/profile/user';
+import userReducer from 'feature/profile/user';
+import locationSlice from 'feature/location/locationSlice';
 
 export const store = configureStore({
   reducer: {
-    user: userReducer
+    user: userReducer,
+    location: locationSlice
   }
 });
 // Infer the `RootState` and `AppDispatch` types from the store itself

--- a/client/src/utils/useSelectorTyped.ts
+++ b/client/src/utils/useSelectorTyped.ts
@@ -1,0 +1,6 @@
+import { useSelector, shallowEqual } from 'react-redux';
+import { RootState } from 'store/store';
+
+export default function useSelectorTyped<T>(fn: (state: RootState) => T): T {
+  return useSelector(fn, shallowEqual);
+}

--- a/client/src/views/components/common/Nav.tsx
+++ b/client/src/views/components/common/Nav.tsx
@@ -1,30 +1,32 @@
-import React, { useEffect, useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import React, { useEffect } from 'react';
 import { Menu, Wrapper } from './nav.style';
 import { Icon } from '../icons';
+import { useLocation } from 'react-router-dom';
+import { useDispatch } from 'react-redux';
+import useSelectorTyped from 'utils/useSelectorTyped';
+import { click } from 'feature/location/locationSlice';
 
 const NO_NAV_ROUTE: readonly string[] = ['/', '/login', '/signup'];
+const ACTIVE_MAIN: readonly string[] = ['/main', '/main2'];
 
 const Nav = () => {
+  const dispatch = useDispatch();
   const location = useLocation();
-  const isHidden = NO_NAV_ROUTE.includes(location.pathname);
-  const [isMainPage, setIsMainPage] = useState(true);
+  const { path } = useSelectorTyped(state => state.location);
+  const isHidden = NO_NAV_ROUTE.includes(path);
+  const isMainPage = ACTIVE_MAIN.includes(path);
 
   useEffect(() => {
-    if (location.pathname.startsWith('/mypage')) {
-      setIsMainPage(false);
-    } else {
-      setIsMainPage(true);
-    }
+    dispatch(click({ path: location.pathname }));
   }, [location.pathname]);
 
   return (
   <Menu hidden={isHidden}>
-    <Wrapper to='/main'>
+    <Wrapper to='/main' isActive={isMainPage}>
       {isMainPage ? <Icon.ActiveLeft /> : <Icon.Left />}
     </Wrapper>
-    <Wrapper to='/mypage'>
-      {isMainPage ? <Icon.Right /> : <Icon.ActiveRight />}
+    <Wrapper to='/mypage' isActive={!isMainPage}>
+      {isMainPage ? <Icon.Right/> : <Icon.ActiveRight/>}
     </Wrapper>
   </Menu>
   );

--- a/client/src/views/components/common/nav.style.tsx
+++ b/client/src/views/components/common/nav.style.tsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import { NavLink } from 'react-router-dom';
+import { Statics } from 'views/components/UI/atoms/static.style';
 
 export const Menu = styled.nav<{ hidden: boolean }>`
   position: fixed;
@@ -11,16 +12,17 @@ export const Menu = styled.nav<{ hidden: boolean }>`
   display: ${p => p.hidden ? 'hidden' : 'flex'};
   align-items: center;
   border-top: 2px solid var(--nav-stroke-green);
-  .active {
-    box-shadow: inset 0 10px 24px hsla(0, 0%, 0%, 0.05), inset 0 2px 4px hsla(0, 0%, 0%, 0.1);
-  }
-`;
+  `;
 
-export const Wrapper = styled(NavLink)`
+export const Wrapper = styled(NavLink).withConfig({
+  shouldForwardProp: (p) => !['isActive'].includes(p)
+})<{ isActive: boolean }>`
+  ${Statics.Trans}
   flex: 1;
   height: 70px;
   display: flex;
   align-items: center;
   justify-content: center;
   background-color: var(--nav-bg-green);
+  box-shadow: ${p => p.isActive ? 'inset 0 10px 24px hsla(0, 0%, 0%, 0.05), inset 0 2px 4px hsla(0, 0%, 0%, 0.1)' : 'none'};
 `;


### PR DESCRIPTION
+ package.json 
리덕스 툴킷 설치했으므로 'redux' 삭제

+ previousChallengesSlice.ts
지난 챌린지 slice 만드는 중입니다

+ locationSlice.ts
location pathname 상태를 리덕스로 관리해서 새로고침해도 navigation UI가 변경되지 않도록 했습니다

+ store.ts
locationSlice 연결

+ Nav, Nav.style 스타일 적용 로직 변경

+ useSelectorTyped.ts
useSelector, shallowEqual 사용을 hook으로 만들었습니다