### PR TITLE
refactor: validate, debounce, handle error for edit userinfo

### DIFF
--- a/client/src/feature/form/index.ts
+++ b/client/src/feature/form/index.ts
@@ -12,15 +12,17 @@ interface SignupForm {
   isValidEmail: boolean
   isValidPassword: boolean
   isValidUserName: boolean
+  requestStatus: string
   error: string
 }
 interface EditForm {
-  username?: string
+  username: string | null
   prePassword: string
-  newPassword?: string
+  newPassword: string | null
   isValidUserName?: boolean
   isValidPrePassword: boolean
   isValidNewPassword?: boolean
+  requestStatus: string
   error: string
 }
 interface IForm {
@@ -42,11 +44,15 @@ const initialState: IForm = {
     isValidEmail: false,
     isValidPassword: false,
     isValidUserName: false,
+    requestStatus: '',
     error: ''
   },
   edit_form: {
+    username: null,
     prePassword: '',
+    newPassword: null,
     isValidPrePassword: false,
+    requestStatus: '',
     error: ''
   }
 };
@@ -133,6 +139,36 @@ export const formSlice = createSlice({
     ) => {
       state.signup_form.error = payload;
     },
+    setSignupRequestStatus: (
+      state,
+      { payload }: PayloadAction<string>
+    ) => {
+      state.signup_form.requestStatus = payload;
+    },
+    setEditUsernameValidity: (
+      state,
+      { payload }: PayloadAction<boolean>
+    ) => {
+      state.edit_form.isValidUserName = payload;
+    },
+    setEditPrePasswordValidity: (
+      state,
+      { payload }: PayloadAction<boolean>
+    ) => {
+      state.edit_form.isValidPrePassword = payload;
+    },
+    setEditNewPasswordValidity: (
+      state,
+      { payload }: PayloadAction<boolean>
+    ) => {
+      state.edit_form.isValidNewPassword = payload;
+    },
+    setEditRequestStatus: (
+      state,
+      { payload }: PayloadAction<string>
+    ) => {
+      state.edit_form.requestStatus = payload;
+    },
     setEditError: (
       state,
       { payload }: PayloadAction<string>
@@ -154,7 +190,12 @@ export const {
   setSignupEmailValidity,
   setSignupPasswordValidity,
   setSignupUsernameValidity,
+  setSignupRequestStatus,
   setSignupError,
+  setEditUsernameValidity,
+  setEditPrePasswordValidity,
+  setEditNewPasswordValidity,
+  setEditRequestStatus,
   setEditError
 } = formSlice.actions;
 export default formSlice.reducer;

--- a/client/src/feature/profile/user.ts
+++ b/client/src/feature/profile/user.ts
@@ -3,7 +3,7 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 interface UserInfoType {
   // [index: string]: string | number
   email: string | null
-  usename: string
+  username: string
   status: string
   progress: number
   challengeType: string | null
@@ -19,7 +19,7 @@ interface UserType {
 
 const initialUserInfo: UserInfoType = {
   email: '',
-  usename: '',
+  username: '',
   status: '',
   progress: -365,
   challengeType: '',
@@ -42,8 +42,8 @@ export const userSlice = createSlice({
       state.loginStatus = true;
     },
 
-    updateUser: (state, { payload }: PayloadAction<Partial<UserInfoType>>) => {
-      state.userInfo = { ...state.userInfo, ...payload };
+    updateUser: (state, { payload }: PayloadAction<string>) => {
+      state.userInfo = { ...state.userInfo, username: payload };
     },
 
     logoutUser: (state) => {

--- a/client/src/types/userTypes.ts
+++ b/client/src/types/userTypes.ts
@@ -9,7 +9,5 @@ export interface LoginData {
 }
 
 export interface EditInfo {
-  username: string
-  prePassword: string | null
-  newPassword: string | null
+  [key: string]: string
 }

--- a/client/src/views/pages/SettingsPage/debouncingChanges.ts
+++ b/client/src/views/pages/SettingsPage/debouncingChanges.ts
@@ -1,0 +1,38 @@
+import debounce from 'utils/debounce';
+import { useDispatch } from 'react-redux';
+import { setEditUsername, setEditPrePW, setEditNewPW, setEditUsernameValidity, setEditPrePasswordValidity, setEditNewPasswordValidity } from 'feature/form';
+import { userNameValidate, passwordValidate } from 'utils/validates';
+
+const handleDebouncedChange = () => {
+  const dispatch = useDispatch();
+
+  const debouncedSetUsername = debounce((value) => dispatch(setEditUsername({ username: value })), 30);
+  const debouncedUsernameValidate = debounce(value => dispatch(setEditUsernameValidity(userNameValidate(value))));
+  const debouncedSetPrePassword = debounce((value) => dispatch(setEditPrePW({ prePassword: value })), 30);
+  const debouncedPrePasswordValidate = debounce((value) => dispatch(setEditPrePasswordValidity(passwordValidate(value))));
+  const debouncedSetNewPassword = debounce((value) => dispatch(setEditNewPW({ newPassword: value })), 30);
+  const debouncedNewPasswordValidate = debounce((value) => dispatch(setEditNewPasswordValidity(passwordValidate(value))));
+
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { id, value } = e.currentTarget;
+    switch (id) {
+      case 'username':
+        debouncedSetUsername(value);
+        debouncedUsernameValidate(value);
+        break;
+      case 'prePassword':
+        debouncedSetPrePassword(value);
+        debouncedPrePasswordValidate(value);
+        break;
+      case 'newPassword':
+        debouncedSetNewPassword(value);
+        debouncedNewPasswordValidate(value);
+        break;
+      default:
+        break;
+    }
+  };
+  return { onChange };
+};
+
+export default handleDebouncedChange;

--- a/client/src/views/pages/SettingsPage/index.tsx
+++ b/client/src/views/pages/SettingsPage/index.tsx
@@ -1,123 +1,77 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { Title, Content } from 'views/components/UI/molecules/text.style';
 import { AuthLabel, AuthInput } from 'views/components/login/style';
 import AlertModal from 'views/components/mainpage/AlertModal';
 import { Form, Btn, Exit } from './SettingsPage.style';
 import { Layout } from 'views/components/UI/Layout.style';
 import MyPageNav from 'views/components/common/MyPageNav';
-import axios from 'axios';
-
-interface UserInfoProps {
-  username?: string
-  prePassword: string
-  newPassword?: string
-}
+import debouncingChanges from './debouncingChanges';
+import useSelectorTyped from 'utils/useSelectorTyped';
+import useSettingsFlows from './useSettingsFlows';
 
 const MypageSettings = () => {
-  const [isCheckedName, setIsCheckedName] = useState(true);
-  const [isCheckedPrePw, setIsCheckedPrePw] = useState(true);
-  const [isCheckedNewPw, setIsCheckedNewPw] = useState(true);
-  const [inputError, setInputError] = useState(false);
-  const [isModalOpen, setIsModalOpen] = useState(false);
-  const [userInfo, setUserInfo] = useState<UserInfoProps>({ prePassword: '' });
+  const [isModalOpen, setIsModalOpen] = React.useState(false);
+  const { username } = useSelectorTyped(state => state.user.userInfo);
+  const { isValidUserName, isValidPrePassword, isValidNewPassword, error } = useSelectorTyped(state => state.form.edit_form);
+  const { onChange } = debouncingChanges();
+  const { doEditInfo } = useSettingsFlows();
 
-  const onChangeInput = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setInputError(false);
-    if (e.currentTarget.id === 'username') {
-      setIsCheckedName(false);
-      if (e.currentTarget.value.length >= 2) {
-        setIsCheckedName(true);
-      }
-    }
-    if (e.currentTarget.id === 'prePassword') {
-      setIsCheckedPrePw(false);
-      if (e.currentTarget.value.length >= 8) {
-        setIsCheckedPrePw(true);
-      }
-    }
-    if (e.currentTarget.id === 'newPassword') {
-      setIsCheckedNewPw(false);
-      if (e.currentTarget.value.length >= 8) {
-        setIsCheckedNewPw(true);
-      }
-    }
-    setUserInfo({ ...userInfo, [e.currentTarget.id]: e.currentTarget.value });
-  };
-
-  const handleSubmitInfo = (e: React.FormEvent<HTMLFormElement>) => {
+  const handleEditInfo = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    if (isCheckedName && isCheckedPrePw && isCheckedNewPw) {
-      console.log(userInfo);
-      axios.patch('https://api.cactus-villeage.com/api/v1/members', userInfo, {
-        withCredentials: true
-      })
-        .then(res => console.log(res))
-        .catch(err => console.log(err));
-    } else {
-      setInputError(true);
-    }
+    void doEditInfo();
   };
 
   return (
     <Layout.PageContainer>
       <MyPageNav />
-    <Title.Main>내 정보 수정</Title.Main>
-    <Form onSubmit={handleSubmitInfo}>
-      <AuthLabel htmlFor="username">닉네임</AuthLabel>
-      <AuthInput
-        id="username"
-        type="text"
-        onChange={onChangeInput}
-        maxLength={8}
-      />
-      {isCheckedName
-        ? null
-        : <Content.Check>
-          닉네임은 2자 이상 8자 이하로 작성해주세요.
-          </Content.Check> }
-      <AuthLabel htmlFor="prePassword">기존 비밀번호</AuthLabel>
-      <AuthInput
-        autoComplete="false"
-        id="prePassword"
-        type="password"
-        required
-        maxLength={20}
-        onChange={onChangeInput}
-      />
-      {isCheckedPrePw
-        ? null
-        : <Content.Check >
-          비밀번호는 8자 이상 20자 이하로 작성해주세요.
-          </Content.Check> }
-      <AuthLabel htmlFor="newPassword">새 비밀번호</AuthLabel>
-      <AuthInput
-        autoComplete="false"
-        id="newPassword"
-        type="password"
-        maxLength={20}
-        onChange={onChangeInput}
-      />
-      {isCheckedNewPw
-        ? null
-        : <Content.Check >
-          비밀번호는 8자 이상 20자 이하로 작성해주세요.
-          </Content.Check>
-      }
-      {inputError
-        ? <Content.Error>
-          변경 실패 : 입력 정보를 확인해주세요.
-          </Content.Error>
+      <Title.Main>내 정보 수정</Title.Main>
+      <Form onSubmit={handleEditInfo}>
+        <AuthLabel htmlFor="username">닉네임</AuthLabel>
+        <AuthInput
+          id="username"
+          type="text"
+          onChange={onChange}
+          maxLength={8}
+          defaultValue={username}
+        />
+        <Content.Check>
+          {(isValidUserName ?? false) ? '' : '새 닉네임은 2자 이상 8자 이하로 작성해주세요.'}
+        </Content.Check>
+        <AuthLabel htmlFor="prePassword">기존 비밀번호</AuthLabel>
+        <AuthInput
+          autoComplete="false"
+          id="prePassword"
+          type="password"
+          required
+          maxLength={20}
+          onChange={onChange}
+        />
+        <Content.Check >
+          {isValidPrePassword ? '' : '기존 비밀번호는 필수 입력 항목입니다.'}
+        </Content.Check>
+        <AuthLabel htmlFor="newPassword">새 비밀번호</AuthLabel>
+        <AuthInput
+          autoComplete="false"
+          id="newPassword"
+          type="password"
+          maxLength={20}
+          onChange={onChange}
+        />
+        <Content.Check >
+          {(isValidNewPassword ?? false) ? '' : '새 비밀번호는 8자 이상 20자 이하로 작성해주세요.'}
+        </Content.Check>
+        <Content.Error>
+          {error === '' ? '' : `변경 실패 : ${error}`}
+        </Content.Error>
+        <Btn type="submit">
+          변경하기
+        </Btn>
+      </Form>
+      <Exit onClick={() => setIsModalOpen(!isModalOpen)}>선인장 키우기를 떠나실 건가요?</Exit>
+      {isModalOpen
+        ? <AlertModal setIsOpen={setIsModalOpen} status="resign" />
         : null
       }
-      <Btn type="submit">
-        변경하기
-      </Btn>
-    </Form>
-    <Exit onClick={() => setIsModalOpen(!isModalOpen)}>선인장 키우기를 떠나실 건가요?</Exit>
-    {isModalOpen
-      ? <AlertModal setIsOpen={setIsModalOpen} status="resign"/>
-      : null
-    }
     </Layout.PageContainer>
   );
 };

--- a/client/src/views/pages/SettingsPage/useSettingsFlows.tsx
+++ b/client/src/views/pages/SettingsPage/useSettingsFlows.tsx
@@ -1,5 +1,51 @@
 import React from 'react';
+import { patchEditInfo } from 'utils/memberApis';
+import useSelectorTyped from 'utils/useSelectorTyped';
+import { setEditError, setEditNewPasswordValidity, setEditRequestStatus, setEditUsernameValidity } from 'feature/form';
+import { updateUser } from 'feature/profile/user';
+import { EditInfo } from 'types/userTypes';
+import { useDispatch } from 'react-redux';
 
-// const useSettingsFlows = () => {
+const useSettingsFlows = () => {
+  const dispatch = useDispatch();
+  const { username, prePassword, newPassword, isValidUserName, isValidPrePassword, isValidNewPassword } = useSelectorTyped((state) => state.form.edit_form);
 
-// }
+  if (username?.length === 0) {
+    dispatch(setEditUsernameValidity(true));
+  }
+  if (newPassword?.length === 0) {
+    dispatch(setEditNewPasswordValidity(true));
+  }
+
+  const inputData: EditInfo = { prePassword };
+  if (username !== null) {
+    inputData.username = username;
+  }
+  if (newPassword !== null) {
+    inputData.newPassword = newPassword;
+  }
+
+  const doEditInfo = async () => {
+    if (!isValidPrePassword) {
+      dispatch(setEditError('변경 실패 : 기존 비밀번호를 확인해주세요'));
+      return false;
+    }
+    if (isValidUserName === false) {
+      dispatch(setEditError('변경 실패 : 닉네임 조건을 확인해주세요'));
+      return false;
+    }
+    if (isValidNewPassword === false) {
+      dispatch(setEditError('변경 실패 : 비밀번호 조건을 확인해주세요'));
+      return false;
+    } else {
+      const { data, status } = await patchEditInfo({ ...inputData });
+      if (status < 300) {
+        dispatch(setEditRequestStatus('변경되었습니다.'));
+        dispatch(updateUser(data.username));
+      } else dispatch(setEditError(data.message));
+    }
+  };
+  return { doEditInfo };
+};
+
+export default useSettingsFlows;

--- a/client/src/views/pages/SettingsPage/useSettingsForm.tsx
+++ b/client/src/views/pages/SettingsPage/useSettingsForm.tsx
@@ -1,1 +1,0 @@
-import React from 'react';

--- a/client/src/views/pages/SignupPage/index.tsx
+++ b/client/src/views/pages/SignupPage/index.tsx
@@ -8,14 +8,13 @@ import useSelectorTyped from 'utils/useSelectorTyped';
 import debouncingChanges from './debouncingChanges';
 
 const Signup = () => {
-  const { email, username, password, isValidEmail, isValidPassword, isValidUserName, error } = useSelectorTyped((state) => state.form.signup_form);
+  const { isValidEmail, isValidPassword, isValidUserName, error } = useSelectorTyped((state) => state.form.signup_form);
   const navigate = useNavigate();
   const { doSignup } = useSignupFlows();
   const { onChange } = debouncingChanges();
 
   const handleSignup = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    console.log({ email, username, password });
     void doSignup();
   };
 
@@ -32,7 +31,6 @@ const Signup = () => {
           id="email"
           type="email"
           required
-          value={email}
           onChange={onChange}
         />
         <Content.Check>
@@ -62,7 +60,7 @@ const Signup = () => {
           {isValidPassword ? '' : '비밀번호의 길이는 8자 이상 20자 이상입니다.'}
         </Content.Check>
         <Content.Error>
-          {error === '' ? '' : '가입 실패 : 입력 정보를 확인해주세요.'}
+          {error === '' ? '' : `가입 실패 : ${error}`}
         </Content.Error>
         <AuthLoginBtn type="submit">
           가입하기

--- a/client/src/views/pages/SignupPage/useSignupFlows.tsx
+++ b/client/src/views/pages/SignupPage/useSignupFlows.tsx
@@ -3,17 +3,19 @@ import { postSignup } from 'utils/memberApis';
 import useSelectorTyped from 'utils/useSelectorTyped';
 import { useNavigate } from 'react-router-dom';
 import { setSignupError } from 'feature/form';
+import { useDispatch } from 'react-redux';
 
 const useSignupFlows = () => {
+  const dispatch = useDispatch();
   const navigate = useNavigate();
-  const { email, username, password } = useSelectorTyped((state) => state.form.signup_form);
+  const { email, username, password, isValidEmail, isValidPassword, isValidUserName } = useSelectorTyped((state) => state.form.signup_form);
 
   const doSignup = async () => {
-    if (email === '' || username === '' || password === '') return false;
+    if (!isValidEmail || !isValidPassword || !isValidUserName) return false;
 
     const { data, status } = await postSignup({ email, username, password });
     if (status < 300) navigate('/login');
-    else setSignupError(data.message);
+    else dispatch(setSignupError(data.message ?? '입력 정보를 확인해주세요.'));
   };
 
   return { doSignup };


### PR DESCRIPTION
+ profile/user.ts, form/index.ts, types/userTypes.ts
Edit UserInfo types 수정

+ debouncingChanges.ts
회원정보 수정페이지 상태관리 디바운싱 적용

+ useSettingsFlows.ts
회원정보 수정 요청 custom hook
useSignupFlows와 함께 응답 실패시 message로  들어오는 값을 화면에 띄우도록 수정

todo: 회원정보 수정 요청과 응답에 관해 백엔드에 질문하기

<img width="1303" alt="스크린샷 2022-10-03 오전 3 30 04" src="https://user-images.githubusercontent.com/104131962/193470676-f6de9f02-dc01-4d43-b114-69dd78e15bb6.png">
