### PR TITLE
style: UI updates for Ranking page share button, Mypage

### DIFF
--- a/client/src/views/components/UI/molecules/button.style.tsx
+++ b/client/src/views/components/UI/molecules/button.style.tsx
@@ -6,6 +6,7 @@ const ShareBtn = styled.button`
   ${Statics.Border1};
   height: 30px;
   width: 90px;
+  min-width: fit-content;
   margin-right: 5px;
   span {
     ${Statics.SpanWithIcon}

--- a/client/src/views/pages/Mypage/index.tsx
+++ b/client/src/views/pages/Mypage/index.tsx
@@ -3,9 +3,11 @@ import { TapHome, TapMenu, TapUserInfo } from './mypage.style';
 import { MypageIcon } from 'views/components/icons/mypage';
 import { useNavigate } from 'react-router-dom';
 import { Layout } from 'views/components/UI/Layout.style';
+import useSelectorTyped from 'utils/useSelectorTyped';
 
 const Mypage = () => {
   const navigate = useNavigate();
+  const { username, email } = useSelectorTyped(state => state.user.userInfo);
 
   return (
     <Layout.PageContainer>
@@ -13,9 +15,9 @@ const Mypage = () => {
         마이페이지
       </TapHome>
       <TapUserInfo role='button' onClick={() => navigate('/settings')}>
-        <div>인장님, 안녕하세요!</div>
+        <div>{username}님, 안녕하세요!</div>
         <MypageIcon.Arrow />
-        <div>abc@naver.com</div>
+        <div>{email}</div>
       </TapUserInfo>
       <TapMenu role='button' onClick={() => navigate('/active-challenges')}>
         <MypageIcon.Garden />

--- a/client/src/views/pages/SettingsPage/index.tsx
+++ b/client/src/views/pages/SettingsPage/index.tsx
@@ -28,6 +28,9 @@ const MypageSettings = () => {
       <MyPageNav />
       <Title.Main>내 정보 수정</Title.Main>
       <Form onSubmit={handleEditInfo}>
+        <Content.Check>
+          📢 카카오/구글로 가입하신 회원은 현재 페이지에서 비밀번호 변경이 불가능합니다.
+        </Content.Check>
         <AuthLabel htmlFor="username">닉네임</AuthLabel>
         <AuthInput
           id="username"


### PR DESCRIPTION
소셜 로그인 이용자 회원정보 수정 제한 안내
랭킹 소셜 공유 버튼 글자 깨짐 조정
마이페이지 진입시 store에서 유저 정보 꺼내오기
<img width="808" alt="스크린샷 2022-10-03 오후 6 51 22" src="https://user-images.githubusercontent.com/104131962/193555193-851e9bb2-e92a-435f-935a-f0dede05330f.png">
<img width="454" alt="스크린샷 2022-10-03 오후 6 53 30" src="https://user-images.githubusercontent.com/104131962/193555195-7e7315a7-6d12-4073-a1d9-ef71fbae79bb.png">
<img width="454" alt="스크린샷 2022-10-03 오후 7 00 14" src="https://user-images.githubusercontent.com/104131962/193555199-28f0ae45-ccf6-4b07-9977-6317fbc47e73.png">
