### PR TITLE
feat: member info - chall type default null to none

### DIFF
--- a/server/server/src/main/java/com/cactusvilleage/server/auth/service/MemberService.java
+++ b/server/server/src/main/java/com/cactusvilleage/server/auth/service/MemberService.java
@@ -166,6 +166,7 @@ public class MemberService {
                     .email(member.getEmail())
                     .username(member.getUsername())
                     .status("none")
+                    .challengeType("none")
                     .providerType(member.getProviderType().toString().toLowerCase())
                     .build();
         } else {


### PR DESCRIPTION
진행중인 챌 없으면 챌 타입 null 로 가던 거 "none"으로 바꿨어여