### PR TITLE
feat: username len constraint added (plain)

### DIFF
--- a/server/server/src/main/java/com/cactusvilleage/server/auth/web/dto/request/EditDto.java
+++ b/server/server/src/main/java/com/cactusvilleage/server/auth/web/dto/request/EditDto.java
@@ -19,6 +19,7 @@ public class EditDto {
     @NotEmpty(message = "변경 닉네임은 필수로 입력되어야 합니다.")
     @SpaceCantBeAtBeginOrEnd
     @UsernameNotDuplicate
+    @Size(min = 2, max = 8, message = "닉네임 길이는 2 이상 8 이하여야 합니다.")
     private String username;
     @PrePasswordRequired
     @Size(min = 8, max = 20, message = "비밀번호 값은 최소 8자에서 최대 20자 이하입니다.")

--- a/server/server/src/main/java/com/cactusvilleage/server/auth/web/dto/request/PlainSignupDto.java
+++ b/server/server/src/main/java/com/cactusvilleage/server/auth/web/dto/request/PlainSignupDto.java
@@ -28,6 +28,7 @@ public class PlainSignupDto {
     @NotBlank
     @UsernameNotDuplicate
     @SpaceCantBeAtBeginOrEnd
+    @Size(min = 2, max = 8, message = "닉네임 길이는 2 이상 8 이하여야 합니다.")
     private String username;
 
     @NotBlank


### PR DESCRIPTION
oauth로 default 닉 == 우리 닉으로 넣으면서 길이 제한 없앴었는데
아아니 지금 보니까 프론트랑 안 맞지 모야? 뿌앵

암튼 그래서 username 제한 걸었어요

1. 회원 가입/닉네임 수정 시 길이는 2 이상 8 이하여야 합니다.
2. 해당 사항 미충족 시 "fieldErrors": [ {"field" : "username, "rejectevalue": "먼가문제가많은닉네임", "reason": "닉네임 길이는 2 이상 8 이하여야 합니다."} ] 형식으로 JSON 응답이 가도록 수정했습니다.

e.g.
![image](https://user-images.githubusercontent.com/85007104/200119939-a75b89e1-2f78-488c-b60f-af3a74ada9dc.png)
 